### PR TITLE
The Filewatcher expect a list of str

### DIFF
--- a/ovos_microphone_plugin_files/__init__.py
+++ b/ovos_microphone_plugin_files/__init__.py
@@ -48,6 +48,7 @@ class FilesMicrophone(Microphone):
         self.current_file = path
 
         try:
+            LOG.debug(f"processing file: {path}")
             audio = self.read_wave_file(path)
             full_chunk = audio.frame_data
             while len(full_chunk) >= self.chunk_size:
@@ -67,9 +68,11 @@ class FilesMicrophone(Microphone):
 
     def read_chunk(self) -> Optional[bytes]:
         assert self._is_running, "Not running"
-        if self.current_file:
-            return self._queue.get(timeout=self.timeout)
-        return b"0" * self.chunk_size  # silence
+        if not self.current_file and self._queue.empty():
+            return None
+
+        LOG.debug("reading chunk")
+        return self._queue.get(timeout=self.timeout)
 
     def stop(self):
         assert self._watcher is not None, "Not started"

--- a/ovos_microphone_plugin_files/__init__.py
+++ b/ovos_microphone_plugin_files/__init__.py
@@ -61,7 +61,7 @@ class FilesMicrophone(Microphone):
 
     def start(self):
         assert self._watcher is None, "Already started"
-        self._watcher = FileWatcher(self.files_folder,
+        self._watcher = FileWatcher([self.files_folder],
                                     callback=self.on_new_file)
         self._is_running = True
 


### PR DESCRIPTION
1. The Filewatcher expects in current version of ovos_utils a list of paths. Sending string leads to the interpretation of the string as a list of chars. Watching for file will always ends with "file not found".
2. The read_chunk method should read the whole queue of bytes to send the expected result to the backend


